### PR TITLE
Fix Data Races

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,4 +1,18 @@
-package logger
+package log
+
+import (
+	"github.com/aws/aws-xray-sdk-go/logger"
+)
+
+func init() {
+	internalLogger = &logger.LoggerImpl{InfoLvl: true}
+}
+
+var internalLogger logger.Logger
+
+func InjectLogger(l logger.Logger) {
+	internalLogger = l
+}
 
 func Debug(msg string) {
 	internalLogger.Debug(msg)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -45,3 +45,7 @@ func Error(msg string) {
 func Errorf(format string, args ...interface{}) {
 	internalLogger.Errorf(format, args)
 }
+
+func GetLogLevel() int {
+	return internalLogger.GetLogLevel()
+}

--- a/logger/log.go
+++ b/logger/log.go
@@ -1,0 +1,33 @@
+package logger
+
+func Debug(msg string) {
+	internalLogger.Debug(msg)
+}
+
+func Debugf(format string, args ...interface{}) {
+	internalLogger.Debugf(format, args)
+}
+
+func Info(msg string) {
+	internalLogger.Info(msg)
+}
+
+func Infof(format string, args ...interface{}) {
+	internalLogger.Infof(format, args)
+}
+
+func Warn(msg string) {
+	internalLogger.Warn(msg)
+}
+
+func Warnf(format string, args ...interface{}) {
+	internalLogger.Warnf(format, args)
+}
+
+func Error(msg string) {
+	internalLogger.Error(msg)
+}
+
+func Errorf(format string, args ...interface{}) {
+	internalLogger.Errorf(format, args)
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,6 +5,13 @@ import (
 	"log"
 )
 
+const (
+	InfoLvl = iota
+	DebugLvl
+	WarnLvl
+	ErrorLvl
+)
+
 type Logger interface {
 	Debug(msg string)
 	Debugf(format string, args ...interface{})
@@ -14,6 +21,7 @@ type Logger interface {
 	Warnf(format string, args ...interface{})
 	Error(msg string)
 	Errorf(format string, args ...interface{})
+	GetLogLevel() int
 }
 
 type LoggerImpl struct {
@@ -66,4 +74,16 @@ func (l *LoggerImpl) Error(msg string) {
 
 func (l *LoggerImpl) Errorf(format string, args ...interface{}) {
 	log.Printf(fmt.Sprintf("[ERROR] %s", format), args)
+}
+
+func (l *LoggerImpl) GetLogLevel() int {
+	if l.InfoLvl {
+		return InfoLvl
+	} else if l.DebugLvl {
+		return DebugLvl
+	} else if l.WarnLvl {
+		return WarnLvl
+	} else {
+		return ErrorLvl
+	}
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,16 +16,6 @@ type Logger interface {
 	Errorf(format string, args ...interface{})
 }
 
-func init() {
-	internalLogger = &LoggerImpl{}
-}
-
-var internalLogger Logger
-
-func InjectLogger(l Logger) {
-	internalLogger = l
-}
-
 type LoggerImpl struct {
 	DebugLvl bool
 	InfoLvl  bool

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,79 @@
+package logger
+
+import (
+	"fmt"
+	"log"
+)
+
+type Logger interface {
+	Debug(msg string)
+	Debugf(format string, args ...interface{})
+	Info(msg string)
+	Infof(format string, args ...interface{})
+	Warn(msg string)
+	Warnf(format string, args ...interface{})
+	Error(msg string)
+	Errorf(format string, args ...interface{})
+}
+
+func init() {
+	internalLogger = &LoggerImpl{}
+}
+
+var internalLogger Logger
+
+func InjectLogger(l Logger) {
+	internalLogger = l
+}
+
+type LoggerImpl struct {
+	DebugLvl bool
+	InfoLvl  bool
+	WarnLvl  bool
+}
+
+//Debug log off by default
+func (l *LoggerImpl) Debug(msg string) {
+	if l.DebugLvl {
+		log.Println(fmt.Sprintf("[DEBUG] %s", msg))
+	}
+}
+
+func (l *LoggerImpl) Debugf(format string, args ...interface{}) {
+	if l.DebugLvl {
+		log.Printf(fmt.Sprintf("[DEBUG] %s", format), args)
+	}
+}
+
+//Info log off by default
+func (l *LoggerImpl) Info(msg string) {
+	if l.DebugLvl || l.InfoLvl {
+		log.Println(fmt.Sprintf("[INFO] %s", msg))
+	}
+}
+
+func (l *LoggerImpl) Infof(format string, args ...interface{}) {
+	if l.DebugLvl || l.InfoLvl {
+		log.Printf(fmt.Sprintf("[INFO] %s", format), args)
+	}
+}
+
+func (l *LoggerImpl) Warn(msg string) {
+	if l.DebugLvl || l.InfoLvl || l.WarnLvl {
+		log.Println(fmt.Sprintf("[WARN] %s", msg))
+	}
+}
+
+func (l *LoggerImpl) Warnf(format string, args ...interface{}) {
+	if l.DebugLvl || l.InfoLvl || l.WarnLvl {
+		log.Printf(fmt.Sprintf("[WARN] %s", format), args)
+	}
+}
+
+func (l *LoggerImpl) Error(msg string) {
+	log.Println(fmt.Sprintf("[ERROR] %s", msg))
+}
+
+func (l *LoggerImpl) Errorf(format string, args ...interface{}) {
+	log.Printf(fmt.Sprintf("[ERROR] %s", format), args)
+}

--- a/plugins/beanstalk/beanstalk.go
+++ b/plugins/beanstalk/beanstalk.go
@@ -12,8 +12,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 func init() {
@@ -27,14 +27,14 @@ func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 
 	rawConfig, err := ioutil.ReadFile(ebConfigPath)
 	if err != nil {
-		logger.Errorf("Unable to read Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
+		log.Errorf("Unable to read Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
 		return
 	}
 
 	config := &plugins.BeanstalkMetadata{}
 	err = json.Unmarshal(rawConfig, config)
 	if err != nil {
-		logger.Errorf("Unable to unmarshal Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
+		log.Errorf("Unable to unmarshal Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
 		return
 	}
 

--- a/plugins/beanstalk/beanstalk.go
+++ b/plugins/beanstalk/beanstalk.go
@@ -13,7 +13,7 @@ import (
 	"io/ioutil"
 
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	log "github.com/cihub/seelog"
+	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 func init() {
@@ -27,14 +27,14 @@ func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 
 	rawConfig, err := ioutil.ReadFile(ebConfigPath)
 	if err != nil {
-		log.Errorf("Unable to read Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
+		logger.Errorf("Unable to read Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
 		return
 	}
 
 	config := &plugins.BeanstalkMetadata{}
 	err = json.Unmarshal(rawConfig, config)
 	if err != nil {
-		log.Errorf("Unable to unmarshal Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
+		logger.Errorf("Unable to unmarshal Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
 		return
 	}
 

--- a/plugins/ec2/ec2.go
+++ b/plugins/ec2/ec2.go
@@ -11,8 +11,8 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 func init() {
@@ -24,13 +24,13 @@ func init() {
 func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 	session, e := session.NewSession()
 	if e != nil {
-		logger.Errorf("Unable to create a new ec2 session: %v", e)
+		log.Errorf("Unable to create a new ec2 session: %v", e)
 		return
 	}
 	client := ec2metadata.New(session)
 	doc, err := client.GetInstanceIdentityDocument()
 	if err != nil {
-		logger.Errorf("Unable to read EC2 instance metadata: %v", err)
+		log.Errorf("Unable to read EC2 instance metadata: %v", err)
 		return
 	}
 

--- a/plugins/ec2/ec2.go
+++ b/plugins/ec2/ec2.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	log "github.com/cihub/seelog"
+	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 func init() {
@@ -24,13 +24,13 @@ func init() {
 func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 	session, e := session.NewSession()
 	if e != nil {
-		log.Errorf("Unable to create a new ec2 session: %v", e)
+		logger.Errorf("Unable to create a new ec2 session: %v", e)
 		return
 	}
 	client := ec2metadata.New(session)
 	doc, err := client.GetInstanceIdentityDocument()
 	if err != nil {
-		log.Errorf("Unable to read EC2 instance metadata: %v", err)
+		logger.Errorf("Unable to read EC2 instance metadata: %v", err)
 		return
 	}
 

--- a/plugins/ecs/ecs.go
+++ b/plugins/ecs/ecs.go
@@ -11,8 +11,8 @@ package ecs
 import (
 	"os"
 
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 func init() {
@@ -25,7 +25,7 @@ func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 	hostname, err := os.Hostname()
 
 	if err != nil {
-		logger.Errorf("Unable to retrieve hostname from OS. %v", err)
+		log.Errorf("Unable to retrieve hostname from OS. %v", err)
 		return
 	}
 

--- a/strategy/ctxmissing/ctxmissing_test.go
+++ b/strategy/ctxmissing/ctxmissing_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	ilog "github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/logger"
 	"github.com/stretchr/testify/assert"
 )
@@ -43,14 +44,7 @@ func (sw *LogWriter) Write(p []byte) (n int, err error) {
 
 func LogSetup() *LogWriter {
 	writer := &LogWriter{}
-	/*
-		logger, err := log.LoggerFromWriterWithMinLevelAndFormat(writer, log.TraceLvl, "%Ns [%Level] %Msg")
-		if err != nil {
-			panic(err)
-		}
-		log.ReplaceLogger(logger)
-	*/
-	logger.InjectLogger(writer)
+	ilog.InjectLogger(writer)
 	return writer
 }
 
@@ -65,8 +59,8 @@ func TestDefaultRuntimeErrorStrategy(t *testing.T) {
 }
 
 func TestDefaultLogErrorStrategy(t *testing.T) {
-	logger := LogSetup()
-	l := NewDefaultLogErrorStrategy()
-	l.ContextMissing("TestLogError")
-	assert.True(t, strings.Contains(logger.Logs[0], "Suppressing AWS X-Ray context missing panic: [[TestLogError]]"))
+	l := LogSetup()
+	s := NewDefaultLogErrorStrategy()
+	s.ContextMissing("TestLogError")
+	assert.True(t, strings.Contains(l.Logs[0], "Suppressing AWS X-Ray context missing panic: [[TestLogError]]"))
 }

--- a/strategy/ctxmissing/ctxmissing_test.go
+++ b/strategy/ctxmissing/ctxmissing_test.go
@@ -9,14 +9,31 @@
 package ctxmissing
 
 import (
-	log "github.com/cihub/seelog"
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"log"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-xray-sdk-go/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 type LogWriter struct {
+	logger.Logger
 	Logs []string
+}
+
+func (l *LogWriter) Debug(msg string)                          {}
+func (l *LogWriter) Debugf(format string, args ...interface{}) {}
+func (l *LogWriter) Info(msg string)                           {}
+func (l *LogWriter) Infof(format string, args ...interface{})  {}
+func (l *LogWriter) Warn(msg string)                           {}
+func (l *LogWriter) Warnf(format string, args ...interface{})  {}
+func (l *LogWriter) Error(msg string)                          {}
+func (l *LogWriter) Errorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args)
+	log.Println(msg)
+	l.Logs = append(l.Logs, msg)
 }
 
 func (sw *LogWriter) Write(p []byte) (n int, err error) {
@@ -26,11 +43,14 @@ func (sw *LogWriter) Write(p []byte) (n int, err error) {
 
 func LogSetup() *LogWriter {
 	writer := &LogWriter{}
-	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(writer, log.TraceLvl, "%Ns [%Level] %Msg")
-	if err != nil {
-		panic(err)
-	}
-	log.ReplaceLogger(logger)
+	/*
+		logger, err := log.LoggerFromWriterWithMinLevelAndFormat(writer, log.TraceLvl, "%Ns [%Level] %Msg")
+		if err != nil {
+			panic(err)
+		}
+		log.ReplaceLogger(logger)
+	*/
+	logger.InjectLogger(writer)
 	return writer
 }
 
@@ -48,5 +68,5 @@ func TestDefaultLogErrorStrategy(t *testing.T) {
 	logger := LogSetup()
 	l := NewDefaultLogErrorStrategy()
 	l.ContextMissing("TestLogError")
-	assert.True(t, strings.Contains(logger.Logs[0], "Suppressing AWS X-Ray context missing panic: TestLogError"))
+	assert.True(t, strings.Contains(logger.Logs[0], "Suppressing AWS X-Ray context missing panic: [[TestLogError]]"))
 }

--- a/strategy/ctxmissing/default_context_missing.go
+++ b/strategy/ctxmissing/default_context_missing.go
@@ -8,7 +8,7 @@
 
 package ctxmissing
 
-import "github.com/aws/aws-xray-sdk-go/logger"
+import "github.com/aws/aws-xray-sdk-go/internal/log"
 
 // RuntimeErrorStrategy provides the AWS_XRAY_CONTEXT_MISSING
 // environment variable value for enabling the runtime error
@@ -48,5 +48,5 @@ func (dr *DefaultRuntimeErrorStrategy) ContextMissing(v interface{}) {
 // ContextMissing logs an error message when the
 // segment context is missing.
 func (dl *DefaultLogErrorStrategy) ContextMissing(v interface{}) {
-	logger.Errorf("Suppressing AWS X-Ray context missing panic: %v", v)
+	log.Errorf("Suppressing AWS X-Ray context missing panic: %v", v)
 }

--- a/strategy/ctxmissing/default_context_missing.go
+++ b/strategy/ctxmissing/default_context_missing.go
@@ -8,9 +8,7 @@
 
 package ctxmissing
 
-import (
-	log "github.com/cihub/seelog"
-)
+import "github.com/aws/aws-xray-sdk-go/logger"
 
 // RuntimeErrorStrategy provides the AWS_XRAY_CONTEXT_MISSING
 // environment variable value for enabling the runtime error
@@ -50,5 +48,5 @@ func (dr *DefaultRuntimeErrorStrategy) ContextMissing(v interface{}) {
 // ContextMissing logs an error message when the
 // segment context is missing.
 func (dl *DefaultLogErrorStrategy) ContextMissing(v interface{}) {
-	log.Errorf("Suppressing AWS X-Ray context missing panic: %v", v)
+	logger.Errorf("Suppressing AWS X-Ray context missing panic: %v", v)
 }

--- a/strategy/sampling/localized.go
+++ b/strategy/sampling/localized.go
@@ -9,7 +9,7 @@
 package sampling
 
 import (
-	"github.com/aws/aws-xray-sdk-go/logger"
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/resources"
 )
 
@@ -60,15 +60,15 @@ func NewLocalizedStrategyFromJSONBytes(b []byte) (*LocalizedStrategy, error) {
 // ShouldTrace consults the LocalizedStrategy's rule set to determine
 // if the given request should be traced or not.
 func (lss *LocalizedStrategy) ShouldTrace(serviceName string, path string, method string) bool {
-	logger.Debugf("Determining ShouldTrace decision for:\n\tserviceName: %s\n\tpath: %s\n\tmethod: %s", serviceName, path, method)
+	log.Debugf("Determining ShouldTrace decision for:\n\tserviceName: %s\n\tpath: %s\n\tmethod: %s", serviceName, path, method)
 	if nil != lss.manifest.Rules {
 		for _, r := range lss.manifest.Rules {
 			if r.AppliesTo(serviceName, path, method) {
-				logger.Debugf("Applicable rule:\n\tfixed_target: %d\n\trate: %f\n\tservice_name: %s\n\turl_path: %s\n\thttp_method: %s", r.FixedTarget, r.Rate, r.ServiceName, r.URLPath, r.HTTPMethod)
+				log.Debugf("Applicable rule:\n\tfixed_target: %d\n\trate: %f\n\tservice_name: %s\n\turl_path: %s\n\thttp_method: %s", r.FixedTarget, r.Rate, r.ServiceName, r.URLPath, r.HTTPMethod)
 				return r.Sample()
 			}
 		}
 	}
-	logger.Debugf("Default rule applies:\n\tfixed_target: %d\n\trate: %f", lss.manifest.Default.FixedTarget, lss.manifest.Default.Rate)
+	log.Debugf("Default rule applies:\n\tfixed_target: %d\n\trate: %f", lss.manifest.Default.FixedTarget, lss.manifest.Default.Rate)
 	return lss.manifest.Default.Sample()
 }

--- a/strategy/sampling/localized.go
+++ b/strategy/sampling/localized.go
@@ -9,8 +9,8 @@
 package sampling
 
 import (
+	"github.com/aws/aws-xray-sdk-go/logger"
 	"github.com/aws/aws-xray-sdk-go/resources"
-	log "github.com/cihub/seelog"
 )
 
 // LocalizedStrategy makes trace sampling decisions based on
@@ -60,15 +60,15 @@ func NewLocalizedStrategyFromJSONBytes(b []byte) (*LocalizedStrategy, error) {
 // ShouldTrace consults the LocalizedStrategy's rule set to determine
 // if the given request should be traced or not.
 func (lss *LocalizedStrategy) ShouldTrace(serviceName string, path string, method string) bool {
-	log.Tracef("Determining ShouldTrace decision for:\n\tserviceName: %s\n\tpath: %s\n\tmethod: %s", serviceName, path, method)
+	logger.Debugf("Determining ShouldTrace decision for:\n\tserviceName: %s\n\tpath: %s\n\tmethod: %s", serviceName, path, method)
 	if nil != lss.manifest.Rules {
 		for _, r := range lss.manifest.Rules {
 			if r.AppliesTo(serviceName, path, method) {
-				log.Tracef("Applicable rule:\n\tfixed_target: %d\n\trate: %f\n\tservice_name: %s\n\turl_path: %s\n\thttp_method: %s", r.FixedTarget, r.Rate, r.ServiceName, r.URLPath, r.HTTPMethod)
+				logger.Debugf("Applicable rule:\n\tfixed_target: %d\n\trate: %f\n\tservice_name: %s\n\turl_path: %s\n\thttp_method: %s", r.FixedTarget, r.Rate, r.ServiceName, r.URLPath, r.HTTPMethod)
 				return r.Sample()
 			}
 		}
 	}
-	log.Tracef("Default rule applies:\n\tfixed_target: %d\n\trate: %f", lss.manifest.Default.FixedTarget, lss.manifest.Default.Rate)
+	logger.Debugf("Default rule applies:\n\tfixed_target: %d\n\trate: %f", lss.manifest.Default.FixedTarget, lss.manifest.Default.Rate)
 	return lss.manifest.Default.Sample()
 }

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-xray-sdk-go/logger"
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/resources"
 )
 
@@ -210,7 +210,7 @@ func parseWhitelistJSON(filename string) []byte {
 	if filename != "" {
 		readBytes, err := ioutil.ReadFile(filename)
 		if err != nil {
-			logger.Errorf("Error occurred while reading customized AWS whitelist JSON file. %v \nReverting to default AWS whitelist JSON file.", err)
+			log.Errorf("Error occurred while reading customized AWS whitelist JSON file. %v \nReverting to default AWS whitelist JSON file.", err)
 		} else {
 			return readBytes
 		}
@@ -229,7 +229,7 @@ func keyValue(r interface{}, tag string) interface{} {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		logger.Errorf("keyValue only accepts structs; got %T", v)
+		log.Errorf("keyValue only accepts structs; got %T", v)
 	}
 	typ := v.Type()
 	for i := 1; i < v.NumField(); i++ {
@@ -312,7 +312,7 @@ func extractParameters(whitelistKey string, rType int, r *request.Request, white
 	if params != nil {
 		children, err := params.children()
 		if err != nil {
-			logger.Errorf("failed to get values for aws attribute: %v", err)
+			log.Errorf("failed to get values for aws attribute: %v", err)
 			return
 		}
 		for _, child := range children {
@@ -336,7 +336,7 @@ func extractDescriptors(whitelistKey string, rType int, r *request.Request, whit
 	if responseDtr != nil {
 		items, err := responseDtr.childrenMap()
 		if err != nil {
-			logger.Errorf("failed to get values for aws attribute: %v", err)
+			log.Errorf("failed to get values for aws attribute: %v", err)
 			return
 		}
 		for k := range items {
@@ -359,7 +359,7 @@ func descriptorType(descriptorMap map[string]interface{}) string {
 	} else if descriptorMap["value"] != nil {
 		typeValue = "value"
 	} else {
-		logger.Error("Missing keys in request / response descriptors in AWS whitelist JSON file.")
+		log.Error("Missing keys in request / response descriptors in AWS whitelist JSON file.")
 	}
 	return typeValue
 }

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-xray-sdk-go/logger"
 	"github.com/aws/aws-xray-sdk-go/resources"
-	log "github.com/cihub/seelog"
 )
 
 type jsonMap struct {
@@ -210,7 +210,7 @@ func parseWhitelistJSON(filename string) []byte {
 	if filename != "" {
 		readBytes, err := ioutil.ReadFile(filename)
 		if err != nil {
-			log.Errorf("Error occurred while reading customized AWS whitelist JSON file. %v \nReverting to default AWS whitelist JSON file.", err)
+			logger.Errorf("Error occurred while reading customized AWS whitelist JSON file. %v \nReverting to default AWS whitelist JSON file.", err)
 		} else {
 			return readBytes
 		}
@@ -229,7 +229,7 @@ func keyValue(r interface{}, tag string) interface{} {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		log.Errorf("keyValue only accepts structs; got %T", v)
+		logger.Errorf("keyValue only accepts structs; got %T", v)
 	}
 	typ := v.Type()
 	for i := 1; i < v.NumField(); i++ {
@@ -312,7 +312,7 @@ func extractParameters(whitelistKey string, rType int, r *request.Request, white
 	if params != nil {
 		children, err := params.children()
 		if err != nil {
-			log.Errorf("failed to get values for aws attribute: %v", err)
+			logger.Errorf("failed to get values for aws attribute: %v", err)
 			return
 		}
 		for _, child := range children {
@@ -336,7 +336,7 @@ func extractDescriptors(whitelistKey string, rType int, r *request.Request, whit
 	if responseDtr != nil {
 		items, err := responseDtr.childrenMap()
 		if err != nil {
-			log.Errorf("failed to get values for aws attribute: %v", err)
+			logger.Errorf("failed to get values for aws attribute: %v", err)
 			return
 		}
 		for k := range items {
@@ -359,7 +359,7 @@ func descriptorType(descriptorMap map[string]interface{}) string {
 	} else if descriptorMap["value"] != nil {
 		typeValue = "value"
 	} else {
-		log.Error("Missing keys in request / response descriptors in AWS whitelist JSON file.")
+		logger.Error("Missing keys in request / response descriptors in AWS whitelist JSON file.")
 	}
 	return typeValue
 }

--- a/xray/capture.go
+++ b/xray/capture.go
@@ -21,7 +21,6 @@ func Capture(ctx context.Context, name string, fn func(context.Context) error) (
 	defer func() {
 		if seg != nil {
 			seg.Close(err)
-
 		} else {
 			privateCfg.ContextMissingStrategy().ContextMissing(fmt.Sprintf("failed to end subsegment: subsegment '%v' cannot be found.", name))
 		}

--- a/xray/client.go
+++ b/xray/client.go
@@ -14,7 +14,7 @@ import (
 	"net/http/httptrace"
 	"strconv"
 
-	"github.com/aws/aws-xray-sdk-go/logger"
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 )
 
 // Client creates a shallow copy of the provided http client,
@@ -58,7 +58,7 @@ func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		seg := GetSegment(ctx)
 		if seg == nil {
 			resp, err = rt.Base.RoundTrip(r)
-			logger.Warnf("failed to record HTTP transaction: segment cannot be found.")
+			log.Warnf("failed to record HTTP transaction: segment cannot be found.")
 			return err
 		}
 

--- a/xray/client.go
+++ b/xray/client.go
@@ -13,7 +13,8 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"strconv"
-	log "github.com/cihub/seelog"
+
+	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 // Client creates a shallow copy of the provided http client,
@@ -57,10 +58,10 @@ func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		seg := GetSegment(ctx)
 		if seg == nil {
 			resp, err = rt.Base.RoundTrip(r)
-			log.Warnf("failed to record HTTP transaction: segment cannot be found.")
+			logger.Warnf("failed to record HTTP transaction: segment cannot be found.")
 			return err
 		}
-		
+
 		ct, e := NewClientTrace(ctx)
 		if e != nil {
 			return e

--- a/xray/config.go
+++ b/xray/config.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/logger"
 	"github.com/aws/aws-xray-sdk-go/strategy/ctxmissing"
 	"github.com/aws/aws-xray-sdk-go/strategy/exception"
@@ -132,7 +133,7 @@ func Configure(c Config) error {
 
 	if c.Logger != nil {
 		privateCfg.logger = c.Logger
-		logger.InjectLogger(privateCfg.logger)
+		log.InjectLogger(privateCfg.logger)
 	}
 
 	switch len(errors) {

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -88,8 +88,6 @@ func ResetConfig() {
 
 	Configure(Config{
 		DaemonAddr:                  "127.0.0.1:2000",
-		LogLevel:                    "info",
-		LogFormat:                   "%Date(2006-01-02T15:04:05Z07:00) [%Level] %Msg%n",
 		SamplingStrategy:            ss,
 		StreamingStrategy:           sms,
 		ExceptionFormattingStrategy: efs,
@@ -99,16 +97,12 @@ func ResetConfig() {
 
 func TestDefaultConfigureParameters(t *testing.T) {
 	daemonAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2000}
-	logLevel := "info"
-	logFormat := "%Date(2006-01-02T15:04:05Z07:00) [%Level] %Msg%n"
 	ss, _ := sampling.NewLocalizedStrategy()
 	efs, _ := exception.NewDefaultFormattingStrategy()
 	sms, _ := NewDefaultStreamingStrategy()
 	cms := ctxmissing.NewDefaultRuntimeErrorStrategy()
 
 	assert.Equal(t, daemonAddr, privateCfg.daemonAddr)
-	assert.Equal(t, logLevel, privateCfg.logLevel.String())
-	assert.Equal(t, logFormat, privateCfg.logFormat)
 	assert.Equal(t, ss, privateCfg.samplingStrategy)
 	assert.Equal(t, efs, privateCfg.exceptionFormattingStrategy)
 	assert.Equal(t, "", privateCfg.serviceVersion)
@@ -118,8 +112,6 @@ func TestDefaultConfigureParameters(t *testing.T) {
 
 func TestSetConfigureParameters(t *testing.T) {
 	daemonAddr := "127.0.0.1:3000"
-	logLevel := "error"
-	logFormat := "[%Level] %Msg%n"
 	serviceVersion := "TestVersion"
 
 	ss := &TestSamplingStrategy{}
@@ -134,13 +126,9 @@ func TestSetConfigureParameters(t *testing.T) {
 		ExceptionFormattingStrategy: efs,
 		StreamingStrategy:           sms,
 		ContextMissingStrategy:      cms,
-		LogLevel:                    logLevel,
-		LogFormat:                   logFormat,
 	})
 
 	assert.Equal(t, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3000}, privateCfg.daemonAddr)
-	assert.Equal(t, logLevel, privateCfg.logLevel.String())
-	assert.Equal(t, logFormat, privateCfg.logFormat)
 	assert.Equal(t, ss, privateCfg.samplingStrategy)
 	assert.Equal(t, efs, privateCfg.exceptionFormattingStrategy)
 	assert.Equal(t, sms, privateCfg.streamingStrategy)

--- a/xray/default_streaming_strategy.go
+++ b/xray/default_streaming_strategy.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/aws/aws-xray-sdk-go/logger"
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 )
 
 var defaultMaxSubsegmentCount = 20
@@ -52,7 +52,7 @@ func (dSS *DefaultStreamingStrategy) RequiresStreaming(seg *Segment) bool {
 // StreamCompletedSubsegments separates subsegments from the provided
 // segment tree and sends them to daemon as streamed subsegment UDP packets.
 func (dSS *DefaultStreamingStrategy) StreamCompletedSubsegments(seg *Segment) [][]byte {
-	logger.Debug("Beginning to stream subsegments.")
+	log.Debug("Beginning to stream subsegments.")
 	var outSegments [][]byte
 	for i := 0; i < len(seg.rawSubsegments); i++ {
 		child := seg.rawSubsegments[i]
@@ -75,11 +75,11 @@ func (dSS *DefaultStreamingStrategy) StreamCompletedSubsegments(seg *Segment) []
 		child.RequestWasTraced = seg.RequestWasTraced
 		cb, _ := json.Marshal(child)
 		outSegments = append(outSegments, cb)
-		logger.Debugf("Streaming subsegment named '%s' from segment tree.", child.Name)
+		log.Debugf("Streaming subsegment named '%s' from segment tree.", child.Name)
 		child.Unlock()
 
 		break
 	}
-	logger.Debug("Finished streaming subsegments.")
+	log.Debug("Finished streaming subsegments.")
 	return outSegments
 }

--- a/xray/default_streaming_strategy.go
+++ b/xray/default_streaming_strategy.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	log "github.com/cihub/seelog"
+	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 var defaultMaxSubsegmentCount = 20
@@ -52,7 +52,7 @@ func (dSS *DefaultStreamingStrategy) RequiresStreaming(seg *Segment) bool {
 // StreamCompletedSubsegments separates subsegments from the provided
 // segment tree and sends them to daemon as streamed subsegment UDP packets.
 func (dSS *DefaultStreamingStrategy) StreamCompletedSubsegments(seg *Segment) [][]byte {
-	log.Trace("Beginning to stream subsegments.")
+	logger.Debug("Beginning to stream subsegments.")
 	var outSegments [][]byte
 	for i := 0; i < len(seg.rawSubsegments); i++ {
 		child := seg.rawSubsegments[i]
@@ -75,11 +75,11 @@ func (dSS *DefaultStreamingStrategy) StreamCompletedSubsegments(seg *Segment) []
 		child.RequestWasTraced = seg.RequestWasTraced
 		cb, _ := json.Marshal(child)
 		outSegments = append(outSegments, cb)
-		log.Tracef("Streaming subsegment named '%s' from segment tree.", child.Name)
+		logger.Debugf("Streaming subsegment named '%s' from segment tree.", child.Name)
 		child.Unlock()
 
 		break
 	}
-	log.Trace("Finished streaming subsegments.")
+	logger.Debug("Finished streaming subsegments.")
 	return outSegments
 }

--- a/xray/emitter.go
+++ b/xray/emitter.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-xray-sdk-go/internal/log"
+	"github.com/aws/aws-xray-sdk-go/logger"
 )
 
 // Header is added before sending segments to daemon.
@@ -43,9 +44,11 @@ func emit(seg *Segment) {
 	}
 
 	for _, p := range packSegments(seg, nil) {
-		b := &bytes.Buffer{}
-		json.Indent(b, p, "", " ")
-		log.Debug(b.String())
+		if log.GetLogLevel() == logger.DebugLvl {
+			b := &bytes.Buffer{}
+			json.Indent(b, p, "", " ")
+			log.Debug(b.String())
+		}
 		e.Lock()
 		_, err := e.conn.Write(append(Header, p...))
 		if err != nil {

--- a/xray/emitter.go
+++ b/xray/emitter.go
@@ -14,7 +14,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/aws/aws-xray-sdk-go/logger"
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 )
 
 // Header is added before sending segments to daemon.
@@ -45,11 +45,11 @@ func emit(seg *Segment) {
 	for _, p := range packSegments(seg, nil) {
 		b := &bytes.Buffer{}
 		json.Indent(b, p, "", " ")
-		logger.Debug(b.String())
+		log.Debug(b.String())
 		e.Lock()
 		_, err := e.conn.Write(append(Header, p...))
 		if err != nil {
-			logger.Error(err.Error())
+			log.Error(err.Error())
 		}
 		e.Unlock()
 	}

--- a/xray/handler.go
+++ b/xray/handler.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-xray-sdk-go/header"
-	"github.com/aws/aws-xray-sdk-go/logger"
+	"github.com/aws/aws-xray-sdk-go/internal/log"
 	"github.com/aws/aws-xray-sdk-go/pattern"
 )
 
@@ -116,13 +116,13 @@ func Handler(sn SegmentNamer, h http.Handler) http.Handler {
 		switch trace["Sampled"] {
 		case "0":
 			seg.Sampled = false
-			logger.Debug("Incoming header decided: Sampled=false")
+			log.Debug("Incoming header decided: Sampled=false")
 		case "1":
 			seg.Sampled = true
-			logger.Debug("Incoming header decided: Sampled=true")
+			log.Debug("Incoming header decided: Sampled=true")
 		default:
 			seg.Sampled = privateCfg.SamplingStrategy().ShouldTrace(r.Host, r.URL.String(), r.Method)
-			logger.Debugf("SamplingStrategy decided: %t", seg.Sampled)
+			log.Debugf("SamplingStrategy decided: %t", seg.Sampled)
 		}
 		if trace["Sampled"] == "?" {
 			respHeader.WriteString(";Sampled=")

--- a/xray/handler.go
+++ b/xray/handler.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 
 	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/logger"
 	"github.com/aws/aws-xray-sdk-go/pattern"
-	log "github.com/cihub/seelog"
 )
 
 // SegmentNamer is the interface for naming service node.
@@ -116,13 +116,13 @@ func Handler(sn SegmentNamer, h http.Handler) http.Handler {
 		switch trace["Sampled"] {
 		case "0":
 			seg.Sampled = false
-			log.Trace("Incoming header decided: Sampled=false")
+			logger.Debug("Incoming header decided: Sampled=false")
 		case "1":
 			seg.Sampled = true
-			log.Trace("Incoming header decided: Sampled=true")
+			logger.Debug("Incoming header decided: Sampled=true")
 		default:
 			seg.Sampled = privateCfg.SamplingStrategy().ShouldTrace(r.Host, r.URL.String(), r.Method)
-			log.Tracef("SamplingStrategy decided: %t", seg.Sampled)
+			logger.Debugf("SamplingStrategy decided: %t", seg.Sampled)
 		}
 		if trace["Sampled"] == "?" {
 			respHeader.WriteString(";Sampled=")


### PR DESCRIPTION
Fixes data race between Context.Done and Segment.Close()

Scenario: When a segment is created, a goroutine is also spawned which listens on the Context.Done channel and flushes the segment if it hasn't been already. Race condition is created when the main application is trying to close the segment and the Context is cancelled at the same time.

Issue: Segment.Close() locks the segment as it modifies a condition to determine whether the segment should be flushed. However, the goroutine doesn't take a lock trying to access that information.

Solution: Refactor flush method itself to not care about locking, and instead have the callers keep track of the locking state.

Refactor injectable logger:
- Rip out dependency on cihub/seelog 
- Instead create an interface in case users of the library want to override
- Create naive implementation using the stdlib "log" library